### PR TITLE
Make test codes be able to be passed.

### DIFF
--- a/src/test/java/io/personium/common/es/impl/EsRetryTest.java
+++ b/src/test/java/io/personium/common/es/impl/EsRetryTest.java
@@ -223,7 +223,8 @@ public class EsRetryTest extends EsTestBase {
             assertEquals("index_for_test_" + EsIndex.CATEGORY_AD, response.getIndex());
             assertEquals("dummyId", response.getId());
             assertEquals("TypeForTest", response.getType());
-            assertEquals(1, response.getVersion());
+            // IndexResponse.getVersion returns 0 if the document already exists.
+            assertEquals(0, response.getVersion());
         } catch (Exception e) {
             e.printStackTrace();
         } finally { // CHECKSTYLE IGNORE
@@ -271,7 +272,8 @@ public class EsRetryTest extends EsTestBase {
             assertEquals("index_for_test_" + EsIndex.CATEGORY_AD, response.getIndex());
             assertEquals("dummyId", response.getId());
             assertEquals("TypeForTest", response.getType());
-            assertEquals(1, response.getVersion());
+            // IndexResponse.getVersion returns 0 if the document already exists.
+            assertEquals(0, response.getVersion());
         } catch (Exception e) {
             e.printStackTrace();
         } finally { // CHECKSTYLE IGNORE

--- a/src/test/java/io/personium/common/es/impl/EsUpdateSettingsTest.java
+++ b/src/test/java/io/personium/common/es/impl/EsUpdateSettingsTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequestBuilder;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
@@ -125,8 +126,11 @@ public class EsUpdateSettingsTest extends EsTestBase {
 
     private String getNumberOfReplicas(TransportClient client, String key) {
         ClusterStateRequestBuilder request = client.admin().cluster().prepareState();
-        ClusterStateResponse response = request.setIndices(index.getName()).execute().actionGet();
-        Settings retrievedSettings = response.getState().getMetaData().index(index.getName()).getSettings();
+        ClusterStateResponse response = request.setIndices(index.getName() + ".*").execute().actionGet();
+        MetaData metadata = response.getState().getMetaData();
+        String firstIndexKey = metadata.getIndices().iterator().next().key;
+
+        Settings retrievedSettings = metadata.index(firstIndexKey).getSettings();
         String numberOfReplicas = retrievedSettings.get(key);
         return numberOfReplicas;
     }


### PR DESCRIPTION

The reasons the test codes cannot be passed.

- The IndexResponse#getVersion returns 0 if the document already exists. ( related to https://github.com/personium/personium-lib-es-adapter/commit/190f5617466760780e0c16e920a134438a57fb3d )
- There are errors when retrieving setting of indexes.

closes #64 